### PR TITLE
fix: minor range bug in svg generation

### DIFF
--- a/flatland/move/flatland/sources/flatland.move
+++ b/flatland/move/flatland/sources/flatland.move
@@ -133,7 +133,7 @@ fun random_color(rng: &mut RandomGenerator): Color {
 }
 
 fun random_sides(rng: &mut RandomGenerator): u8 {
-    rng.generate_u8_in_range(3, 15)
+    rng.generate_u8_in_range(3, 14)
 }
 
 public fun to_b36(addr: address): String {


### PR DESCRIPTION
Fixes a minor bug in the svg generation:
There are only 14 possible number of sides (in the pre-generated svg), but the random generator went up to 15.

This assumes that the `generate_u8_in_range` function generates numbers extremes included.